### PR TITLE
only add tag if geoip isnt "Reserved" or "Unknown"

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -56,7 +56,9 @@ function ProcessMsg(msg,GlobalLables,thread) {
         var Res = EnsureWeHaveLabel(GlobalLables,Orign);
         GlobalLables = Res[1];
         Label = Res[0];
-        thread.addLabel(Label)
+        if (Orign != "Reserved" && Orign != "Unknown") {
+          thread.addLabel(Label);
+        }
         break;
       }
     }


### PR DESCRIPTION
I feeel that tags like "geoip/reserved" are less than useful, so user's would rather not have their inboxes cluttered up with the extra labels.
